### PR TITLE
Add support C-e and C-y scroll line motions.

### DIFF
--- a/XVim2/SourceViewProtocol.h
+++ b/XVim2/SourceViewProtocol.h
@@ -115,7 +115,7 @@ typedef NS_ENUM(char, CursorStyle) { CursorStyleVerticalBar, CursorStyleBlock, C
 
 // Scrolling
 @protocol SourceViewScrollingProtocol <NSObject>
-- (void)xvim_scroll:(CGFloat)ratio count:(NSUInteger)count;
+- (void)xvim_scroll:(XVIM_SCROLL_TYPE)type direction:(XVIM_SCROLL_DIRECTION)direction count:(NSUInteger)count;
 - (void)xvim_pageForward:(NSUInteger)index count:(NSUInteger)count;
 - (void)xvim_pageBackward:(NSUInteger)index count:(NSUInteger)count;
 - (void)xvim_halfPageForward:(NSUInteger)index count:(NSUInteger)count;

--- a/XVim2/XVim/XVimDefs.h
+++ b/XVim2/XVim/XVimDefs.h
@@ -59,6 +59,16 @@ typedef enum {
     XVIM_VISUAL_BOTTOMRIGHT = 3,
 } XVIM_VISUAL_CORNER;
 
+typedef enum {
+    XVIM_SCROLL_TYPE_PAGE,
+    XVIM_SCROLL_TYPE_HALF_PAGE,
+    XVIM_SCROLL_TYPE_LINE,
+} XVIM_SCROLL_TYPE;
+
+typedef NS_ENUM(NSInteger, XVIM_SCROLL_DIRECTION) {
+    XVIM_SCROLL_DIRECTION_UP = -1,
+    XVIM_SCROLL_DIRECTION_DOWN = 1,
+};
 
 typedef NS_OPTIONS(NSUInteger, XVimSortOptions) {
     XVimSortOptionReversed = 1,

--- a/XVim2/XVim/XVimNormalEvaluator.m
+++ b/XVim2/XVim/XVimNormalEvaluator.m
@@ -210,6 +210,11 @@
     return nil;
 }
 
+- (XVimEvaluator*)C_y {
+    [[self sourceView] xvim_scrollLineBackward:[self numericArg]];
+    return nil;
+}
+
 
 // MOTION
 #pragma mark - MOTION
@@ -554,11 +559,6 @@
 }
 
 
-
-- (XVimEvaluator*)C_y{
-    [[self sourceView] xvim_scrollLineBackward:[self numericArg]];
-    return nil;
-}
 
 - (XVimEvaluator*)AT{
     if( [XVim instance].isExecuting ){

--- a/XVim2/XVim/XVimVisualEvaluator.m
+++ b/XVim2/XVim/XVimVisualEvaluator.m
@@ -278,6 +278,12 @@ static NSString* MODE_STRINGS[] = { @"", @"-- VISUAL --", @"-- VISUAL LINE --", 
     return [self d];
 }
 
+- (XVimEvaluator*)C_e
+{
+    [[self sourceView] xvim_scrollLineForward:[self numericArg]];
+    return self;
+}
+
 - (XVimEvaluator*)C_f
 {
     [[self sourceView] xvim_scrollPageForward:[self numericArg]];
@@ -460,6 +466,12 @@ static NSString* MODE_STRINGS[] = { @"", @"-- VISUAL --", @"-- VISUAL LINE --", 
         [self.sourceView xvim_changeSelectionMode:XVIM_VISUAL_LINE];
     }
     return [self y];
+}
+
+- (XVimEvaluator*)C_y
+{
+    [[self sourceView] xvim_scrollLineBackward:[self numericArg]];
+    return self;
 }
 
 - (XVimEvaluator*)DQUOTE

--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
@@ -39,13 +39,23 @@
     }
 }
 
-
-- (void)xvim_scroll:(CGFloat)ratio count:(NSUInteger)count
+- (void)xvim_scroll:(XVIM_SCROLL_TYPE)type direction:(XVIM_SCROLL_DIRECTION)direction count:(NSUInteger)count
 {
     NSInteger cursorLine = self.insertionLine - 1;
 
     // Scroll to the new location
-    NSInteger numScrollLines = (NSInteger)(self.linesPerPage * ratio);
+    NSInteger numScrollLines;
+    switch (type) {
+        case XVIM_SCROLL_TYPE_PAGE:
+            numScrollLines = (NSInteger)(self.linesPerPage) * direction * count;
+            break;
+        case XVIM_SCROLL_TYPE_HALF_PAGE:
+            numScrollLines = (NSInteger)(self.linesPerPage * 0.5) * direction * count;
+            break;
+        case XVIM_SCROLL_TYPE_LINE:
+            numScrollLines = direction * count;
+            break;
+    }
 
     NSPoint bottomPoint = NSMakePoint(0.0, self.contentSize.height);
 
@@ -132,22 +142,32 @@
 
 - (void)xvim_pageForward:(NSUInteger)index count:(NSUInteger)count
 { // C-f
-    [self xvim_scroll:1.0 count:count];
+    [self xvim_scroll:XVIM_SCROLL_TYPE_PAGE direction:XVIM_SCROLL_DIRECTION_DOWN count:count];
 }
 
 - (void)xvim_pageBackward:(NSUInteger)index count:(NSUInteger)count
 { // C-b
-    [self xvim_scroll:-1.0 count:count];
+    [self xvim_scroll:XVIM_SCROLL_TYPE_PAGE direction:XVIM_SCROLL_DIRECTION_UP count:count];
 }
 
 - (void)xvim_halfPageForward:(NSUInteger)index count:(NSUInteger)count
 { // C-d
-    [self xvim_scroll:0.5 count:count];
+    [self xvim_scroll:XVIM_SCROLL_TYPE_HALF_PAGE direction:XVIM_SCROLL_DIRECTION_DOWN count:count];
 }
 
 - (void)xvim_halfPageBackward:(NSUInteger)index count:(NSUInteger)count
 { // C-u
-    [self xvim_scroll:-0.5 count:count];
+    [self xvim_scroll:XVIM_SCROLL_TYPE_HALF_PAGE direction:XVIM_SCROLL_DIRECTION_UP count:count];
+}
+
+- (void)xvim_lineDown:(NSUInteger)index count:(NSUInteger)count
+{ // C-e
+    [self xvim_scroll:XVIM_SCROLL_TYPE_LINE direction:XVIM_SCROLL_DIRECTION_DOWN count:count];
+}
+
+- (void)xvim_lineUp:(NSUInteger)index count:(NSUInteger)count
+{ // C-y
+    [self xvim_scroll:XVIM_SCROLL_TYPE_LINE direction:XVIM_SCROLL_DIRECTION_UP count:count];
 }
 
 - (void)xvim_scrollPageForward:(NSUInteger)count { [self xvim_pageForward:self.insertionPoint count:count]; }
@@ -158,17 +178,7 @@
 
 - (void)xvim_scrollHalfPageBackward:(NSUInteger)count { [self xvim_halfPageBackward:self.insertionPoint count:count]; }
 
-- (void)xvim_scrollLineForward:(NSUInteger)count
-{
-#ifdef TODO
-    [self xvim_lineDown:self.insertionPoint count:count];
-#endif
-}
+- (void)xvim_scrollLineForward:(NSUInteger)count { [self xvim_lineDown:self.insertionPoint count:count]; }
 
-- (void)xvim_scrollLineBackward:(NSUInteger)count
-{
-#ifdef TODO
-    [self xvim_lineUp:self.insertionPoint count:count];
-#endif
-}
+- (void)xvim_scrollLineBackward:(NSUInteger)count { [self xvim_lineUp:self.insertionPoint count:count]; }
 @end


### PR DESCRIPTION
Hi XVim developers.

Scroll one line motions(`C_e` and `C_y`) implementation are  already almost finished and marked as TODO.

I change `-[xvim_scroll:count:]` method to support line scroll and call it from `C_e` and `C_y`.

Thanks.