### PR TITLE
don't move cursor on ctrl-e, ctrl-y

### DIFF
--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
@@ -60,7 +60,14 @@
     }
 
     LineRange visibleLineRange = [self xvim_visibleLineRange];
-    
+    NSInteger actualScrolledLines = numScrollLines;
+    if (numScrollLines < 0) {
+      actualScrolledLines = -MIN(visibleLineRange.topLine, -numScrollLines);
+    } else {
+      actualScrolledLines =
+      MIN(self.lineCount - visibleLineRange.bottomLine - 1, numScrollLines);
+    }
+
     NSInteger scrollToLine = (numScrollLines < 0) ? (visibleLineRange.topLine + numScrollLines) : (visibleLineRange.bottomLine + numScrollLines);
     clamp(scrollToLine, 0, self.lineCount - 1);
 
@@ -71,9 +78,9 @@
     // Update cursor
     switch (type) {
       case XVIM_SCROLL_TYPE_LINE:
-        visibleLineRange = [self xvim_visibleLineRange];
-        cursorLine = MAX(cursorLine, visibleLineRange.topLine);
-        cursorLine = MIN(cursorLine, visibleLineRange.bottomLine);
+        clamp(cursorLine,
+              visibleLineRange.topLine + actualScrolledLines,
+              visibleLineRange.bottomLine + actualScrolledLines);
         break;
       default:
         cursorLine += numScrollLines;

--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
@@ -60,13 +60,6 @@
     }
 
     LineRange visibleLineRange = [self xvim_visibleLineRange];
-    NSInteger actualScrolledLines = numScrollLines;
-    if (numScrollLines < 0) {
-      actualScrolledLines = -MIN(visibleLineRange.topLine, -numScrollLines);
-    } else {
-      actualScrolledLines =
-      MIN(self.lineCount - visibleLineRange.bottomLine - 1, numScrollLines);
-    }
 
     NSInteger scrollToLine = (numScrollLines < 0) ? (visibleLineRange.topLine + numScrollLines) : (visibleLineRange.bottomLine + numScrollLines);
     clamp(scrollToLine, 0, self.lineCount - 1);
@@ -77,11 +70,18 @@
 
     // Update cursor
     switch (type) {
-      case XVIM_SCROLL_TYPE_LINE:
+      case XVIM_SCROLL_TYPE_LINE: {
+        NSInteger numLinesActuallyScrolled;
+        if (numScrollLines < 0) {
+          numLinesActuallyScrolled = -MIN(visibleLineRange.topLine, -numScrollLines);
+        } else {
+          numLinesActuallyScrolled = MIN(self.lineCount - visibleLineRange.bottomLine - 1, numScrollLines);
+        }
         clamp(cursorLine,
-              visibleLineRange.topLine + actualScrolledLines,
-              visibleLineRange.bottomLine + actualScrolledLines);
+              visibleLineRange.topLine + numLinesActuallyScrolled,
+              visibleLineRange.bottomLine + numLinesActuallyScrolled);
         break;
+      }
       default:
         cursorLine += numScrollLines;
         break;

--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
@@ -69,7 +69,16 @@
     [self scrollRangeToVisible:scrollToCharRange];
 
     // Update cursor
-    cursorLine += numScrollLines;
+    switch (type) {
+      case XVIM_SCROLL_TYPE_LINE:
+        visibleLineRange = [self xvim_visibleLineRange];
+        cursorLine = MAX(cursorLine, visibleLineRange.topLine);
+        cursorLine = MIN(cursorLine, visibleLineRange.bottomLine);
+        break;
+      default:
+        cursorLine += numScrollLines;
+        break;
+    }
     clamp(cursorLine, 0, self.lineCount - 1);
 
     _auto newCharRange = [self characterRangeForLineRange:NSMakeRange(cursorLine, 1)];

--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Scrolling.m
@@ -73,9 +73,9 @@
       case XVIM_SCROLL_TYPE_LINE: {
         NSInteger numLinesActuallyScrolled;
         if (numScrollLines < 0) {
-          numLinesActuallyScrolled = -MIN(visibleLineRange.topLine, -numScrollLines);
+          numLinesActuallyScrolled = -MIN(visibleLineRange.topLine+1, -numScrollLines);
         } else {
-          numLinesActuallyScrolled = MIN(self.lineCount - visibleLineRange.bottomLine - 1, numScrollLines);
+          numLinesActuallyScrolled = MIN(self.lineCount - visibleLineRange.bottomLine, numScrollLines);
         }
         clamp(cursorLine,
               visibleLineRange.topLine + numLinesActuallyScrolled,


### PR DESCRIPTION
don't move cursor on ctrl-e, ctrl-y except to keep it on the screen.  This is how vim works.