### PR TITLE
xcode10 b3 - fix selection on source editor

### DIFF
--- a/XVim2/Xcode/Swift/SourceCodeEditorViewWrapper.swift
+++ b/XVim2/Xcode/Swift/SourceCodeEditorViewWrapper.swift
@@ -61,7 +61,7 @@ class SourceCodeEditorViewWrapper: NSObject {
     private let fpGetCursorStyle                = function_ptr_from_name("_$S12SourceEditor0aB4ViewC11cursorStyleAA0ab6CursorE0Ovg", nil)
     private let fpGetDataSource                 = function_ptr_from_name("_$S12SourceEditor0aB4ViewC04dataA0AA0ab4DataA0Cvg", nil)
     private let fpSetSelectedRangeWithModifiers = function_ptr_from_name("_$S12SourceEditor0aB4ViewC16setSelectedRange_9modifiersyAA0abF0V_AA0aB18SelectionModifiersVtF", nil)
-    private let fpAddSelectedRangeWithModifiers = function_ptr_from_name("_$S12SourceEditor0aB4ViewC16addSelectedRange_9modifiersyAA0abF0V_AA0aB18SelectionModifiersVtF", nil)
+    private let fpAddSelectedRangeWithModifiers = function_ptr_from_name("_$S12SourceEditor0aB4ViewC16addSelectedRange_9modifiers15scrollPlacement12alwaysScrollyAA0abF0V_AA0aB18SelectionModifiersVAA0kI0OSgSbtF", nil)
     /* not work in Xcode10
     private let fpFuncLinesPerPage              = function_ptr_from_name("_$S12SourceEditor0aB4ViewC12linesPerPageSiyF", nil)
      */


### PR DESCRIPTION
This fixes the selection on Xcode 10 beta 3, on which the signature of `addSelectedRange:modifiers:` was changed to `addSelectedRange:modifiers:scrollPlacement:alwaysScroll:`.

```
unmangled:
SourceEditor.SourceEditorView.addSelectedRange(_: SourceEditor.SourceEditorRange, modifiers: SourceEditor.SourceEditorSelectionModifiers, scrollPlacement: SourceEditor.ScrollPlacement?, alwaysScroll: Swift.Bool) -> ()

mangled:
_$S12SourceEditor0aB4ViewC16addSelectedRange_9modifiers15scrollPlacement12alwaysScrollyAA0abF0V_AA0aB18SelectionModifiersVAA0kI0OSgSbtF
```

If we want to keep in sync the definition of the methods on the wrapper objects we might need to change as well on SourceCodeEditorViewWrapper.swift.