### PR TITLE
Fix for #176 to allow sourcing xvimrc

### DIFF
--- a/XVim2/XVim/XVim.h
+++ b/XVim2/XVim/XVim.h
@@ -98,6 +98,7 @@ extern NSString* const XVimDocumentPathKey;
  **/
 - (void)writeToConsole:(NSString*)fmt, ...;
 - (void)registerWindow:(XVimWindow*)win;
+- (void)sourceRcFile;
 
 @end
 

--- a/XVim2/XVim/XVim.m
+++ b/XVim2/XVim/XVim.m
@@ -197,6 +197,17 @@
     }
 }
 
+- (void)sourceRcFile{
+    for (NSUInteger mode = XVIM_MODE_NONE; mode < XVIM_MODE_COUNT; mode++) {
+        XVimKeymap *keymap = [self keymapForMode:mode];
+        [keymap clear];
+    }
+    [self.options removeObserver:self forKeyPath:@"debug"];
+    self.options = [[XVimOptions alloc] init];
+    [_options addObserver:self forKeyPath:@"debug" options:NSKeyValueObservingOptionNew context:nil];
+    [self parseRcFile];
+}
+
 - (void)observeValueForKeyPath:(NSString*)keyPath
                           ofObject:(id)object
                             change:(NSDictionary*)change
@@ -382,6 +393,7 @@ static id _startupObservation = nil;
         [self disableXVim];
     }
     else {
+        [self sourceRcFile];
         [self enableXVim];
     }
 }

--- a/XVim2/XVim/XVimExCommand.m
+++ b/XVim2/XVim/XVimExCommand.m
@@ -1191,6 +1191,10 @@ xvim_ignore_warning_undeclared_selector_push
     [view xvim_sortLinesFrom:args.lineBegin to:args.lineEnd withOptions:options];
 }
 
+- (void)source:(XVimExArg*)args inWindow:(XVimWindow*)window{
+	[XVIM sourceRcFile];
+}
+
 - (void)splitview:(XVimExArg*)args inWindow:(XVimWindow*)window
 {
     [XVimLastActiveWorkspaceTabController() xvim_addEditorHorizontally];


### PR DESCRIPTION
Fix for #176 to allow reloading of the xvimrc.  Also implements `source:inWindow` so that the `source` command can be used.