### PR TITLE
Only enable XVim for IDESourceEditorView

### DIFF
--- a/XVim2/Xcode/XVimIDEPegasusSourceEditorView.m
+++ b/XVim2/Xcode/XVimIDEPegasusSourceEditorView.m
@@ -113,7 +113,8 @@ CONST_STR(EDWindow);
 - (XVimWindow*)xvim_window
 {
     XVimWindow* w = [self extraDataForName:EDWindow];
-    if (w == nil || (NSNull*)w == NSNull.null) {
+    if ((w == nil || (NSNull*)w == NSNull.null)
+            && [self.class isEqual:NSClassFromString(@"IDESourceEditor.IDESourceEditorView")]) {
         _auto p = [[SourceCodeEditorViewProxy alloc] initWithSourceCodeEditorView:SELF];
         w = [[XVimWindow alloc] initWithEditorView:p];
         [self setExtraData:w forName:EDWindow];


### PR DESCRIPTION
The IDEConsoleEditorView didn't need commandline, actually it
didn't need XVim, Fix #170