### PR TITLE
Fix for put from register in visual mode

### DIFF
--- a/XVim2/UnitTest/XVimTester+Register.m
+++ b/XVim2/UnitTest/XVimTester+Register.m
@@ -36,6 +36,11 @@
                                    @"ddd e-e fff\n"
                                    @"ggg hhh i_i\n"
                                    @"    jjj kkk";
+    
+    static NSString* register_visual_paste_result = @"aa bbb ccc\n"
+                                                    @"ddd e-e fff\n"
+                                                    @"ggg hhh i_i\n"
+                                                    @"    jjj kkk";
 
     return @[
         // Operation using registers
@@ -65,6 +70,9 @@
 
         // Repeat by @@
         XVimMakeTestCase(@"aaa bbb ccc", 0, 0, @"qallq@a2@@", @"aaa bbb ccc", 8, 0),
+        
+        //pasting from register in visual mode does not modify the pasting register
+        XVimMakeTestCase(text, 0, 0, @"\"adwvw\"aP\"aP", register_visual_paste_result, 0, 0),
     ];
 }
 

--- a/XVim2/XVim/Evaluator/XVimEvaluator.m
+++ b/XVim2/XVim/Evaluator/XVimEvaluator.m
@@ -191,9 +191,9 @@ static XVimEvaluator* s_popEvaluator = nil;
     [XVIM.registerManager yank:yankedText withType:type onRegister:self.yankRegister];
 }
 
-- (void)textView:(id)view didDelete:(NSString*)deletedText withType:(XVIM_TEXT_TYPE)type
+- (void)textView:(id)view didDelete:(NSString*)deletedText withType:(XVIM_TEXT_TYPE)type shouldReplaceRegister:(BOOL)isReplacing
 {
-    [XVIM.registerManager delete:deletedText withType:type onRegister:self.yankRegister];
+    [XVIM.registerManager delete:deletedText withType:type onRegister:self.yankRegister shouldReplaceRegister:isReplacing];
 }
 
 - (XVimCommandLineEvaluator*)searchEvaluatorForward:(BOOL)forward

--- a/XVim2/XVim/SourceViewProtocol.h
+++ b/XVim2/XVim/SourceViewProtocol.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(char, CursorStyle) {
 
 @protocol XVimTextViewDelegateProtocol
 - (void)textView:(id)view didYank:(NSString*)yankedText withType:(XVIM_TEXT_TYPE)type;
-- (void)textView:(id)view didDelete:(NSString*)deletedText withType:(XVIM_TEXT_TYPE)type;
+- (void)textView:(id)view didDelete:(NSString*)deletedText withType:(XVIM_TEXT_TYPE)type shouldReplaceRegister:(bool)isReplacing;
 @end
 
 @protocol SourceViewProtocol <NSObject>

--- a/XVim2/XVim/XVimRegister.h
+++ b/XVim2/XVim/XVimRegister.h
@@ -42,7 +42,7 @@
  **/
 - (XVimString*)xvimStringForRegister:(NSString*)name;
 - (void)yank:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name;
-- (void)delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name shouldReplaceRegister:(BOOL)isReplace;
+- (void)delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name shouldReplaceRegister:(BOOL)isReplacing;
 - (void)textInserted:(XVimString*)string withType:(XVIM_TEXT_TYPE)type;
 - (void)commandExecuted:(XVimString*)string withType:(XVIM_TEXT_TYPE)type;
 - (void)registerExecuted:(NSString*)name;

--- a/XVim2/XVim/XVimRegister.h
+++ b/XVim2/XVim/XVimRegister.h
@@ -42,7 +42,7 @@
  **/
 - (XVimString*)xvimStringForRegister:(NSString*)name;
 - (void)yank:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name;
-- (void)delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name;
+- (void)delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name shouldReplaceRegister:(BOOL)isReplace;
 - (void)textInserted:(XVimString*)string withType:(XVIM_TEXT_TYPE)type;
 - (void)commandExecuted:(XVimString*)string withType:(XVIM_TEXT_TYPE)type;
 - (void)registerExecuted:(NSString*)name;

--- a/XVim2/XVim/XVimRegister.m
+++ b/XVim2/XVim/XVimRegister.m
@@ -289,7 +289,7 @@ static const NSString* s_enum_registers = @"\"0123456789abcdefghijklmnopqrstuvwx
     }
 }
 
-- (void) delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name
+- (void) delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name shouldReplaceRegister:(BOOL)isReplacingRegister
 {
     // TODO: use "- when deleting does not include \n
     NSAssert([self isValidForYank:name], @"Must be valid register for yank/delete");
@@ -314,7 +314,11 @@ static const NSString* s_enum_registers = @"\"0123456789abcdefghijklmnopqrstuvwx
             [self appendXVimString:string forReg:name];
         }
         else {
-            [self setXVimString:string withType:type forReg:name];
+            if (isReplacingRegister) {
+                [self setXVimString:string withType:type forReg:name];
+            } else {
+                [self setXVimString:string withType:type forReg:@"0"];
+            }
         }
     }
 

--- a/XVim2/XVim/XVimRegister.m
+++ b/XVim2/XVim/XVimRegister.m
@@ -289,7 +289,7 @@ static const NSString* s_enum_registers = @"\"0123456789abcdefghijklmnopqrstuvwx
     }
 }
 
-- (void) delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name shouldReplaceRegister:(BOOL)isReplacingRegister
+- (void) delete:(XVimString*)string withType:(XVIM_TEXT_TYPE)type onRegister:(NSString*)name shouldReplaceRegister:(BOOL)isReplacing
 {
     // TODO: use "- when deleting does not include \n
     NSAssert([self isValidForYank:name], @"Must be valid register for yank/delete");
@@ -314,7 +314,7 @@ static const NSString* s_enum_registers = @"\"0123456789abcdefghijklmnopqrstuvwx
             [self appendXVimString:string forReg:name];
         }
         else {
-            if (isReplacingRegister) {
+            if (isReplacing) {
                 [self setXVimString:string withType:type forReg:name];
             } else {
                 [self setXVimString:string withType:type forReg:@"0"];

--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Operations.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Operations.m
@@ -110,6 +110,7 @@
         return NO;
     }
     NSUInteger newPos = NSNotFound;
+    BOOL isYankingFromVisual = true;
 
     [self xvim_beginEditTransaction];
     xvim_on_exit { [self xvim_endEditTransaction]; };
@@ -168,6 +169,7 @@
     		{
     			XVimSelection sel = [self _xvim_selectedBlock];
     			if (yank) {
+                    isYankingFromVisual = false;
     				[self _xvim_yankSelection:sel];
     			}
     			[self _xvim_killSelection:sel];
@@ -184,6 +186,7 @@
                 // This is because of the fact that NSTextView does not allow select EOF
 
                 if (yank) {
+                    isYankingFromVisual = false;
                     [self _xvim_yankRange:range withType:DEFAULT_MOTION_TYPE];
                 }
                 [self insertText:@"" replacementRange:range];
@@ -199,7 +202,7 @@
 			break;
     }
 
-    [self.xvimTextViewDelegate textView:self didDelete:self.lastYankedText withType:self.lastYankedType];
+    [self.xvimTextViewDelegate textView:self didDelete:self.lastYankedText withType:self.lastYankedType shouldReplaceRegister:isYankingFromVisual];
     [self xvim_changeSelectionMode:XVIM_VISUAL_NONE];
     if (newPos != NSNotFound) {
         [self xvim_moveCursor:newPos preserveColumn:NO];

--- a/XVim2/Xcode/SourceCodeEditorViewProxy+Operations.m
+++ b/XVim2/Xcode/SourceCodeEditorViewProxy+Operations.m
@@ -110,7 +110,7 @@
         return NO;
     }
     NSUInteger newPos = NSNotFound;
-    BOOL isYankingFromVisual = true;
+    BOOL isYankingFromVisual = false;
 
     [self xvim_beginEditTransaction];
     xvim_on_exit { [self xvim_endEditTransaction]; };
@@ -169,7 +169,7 @@
     		{
     			XVimSelection sel = [self _xvim_selectedBlock];
     			if (yank) {
-                    isYankingFromVisual = false;
+                    isYankingFromVisual = true;
     				[self _xvim_yankSelection:sel];
     			}
     			[self _xvim_killSelection:sel];
@@ -186,7 +186,7 @@
                 // This is because of the fact that NSTextView does not allow select EOF
 
                 if (yank) {
-                    isYankingFromVisual = false;
+                    isYankingFromVisual = true;
                     [self _xvim_yankRange:range withType:DEFAULT_MOTION_TYPE];
                 }
                 [self insertText:@"" replacementRange:range];
@@ -202,7 +202,7 @@
 			break;
     }
 
-    [self.xvimTextViewDelegate textView:self didDelete:self.lastYankedText withType:self.lastYankedType shouldReplaceRegister:isYankingFromVisual];
+    [self.xvimTextViewDelegate textView:self didDelete:self.lastYankedText withType:self.lastYankedType shouldReplaceRegister:!isYankingFromVisual];
     [self xvim_changeSelectionMode:XVIM_VISUAL_NONE];
     if (newPos != NSNotFound) {
         [self xvim_moveCursor:newPos preserveColumn:NO];


### PR DESCRIPTION
In order to resolve #214 

> ### Operation
> If I yank to register a, then yank to register b, then put register a to replace string C, then register a will have C and b will remain unchanged.
> 
> ### Expected behaviour
> When putting a register's contents, whatever gets replaced should go into the default register but not the specific register used. At least that's the default behavior in my version of Vim.