### PR TITLE
Add UUID for Xcode 11.2

### DIFF
--- a/XVim2/Info.plist
+++ b/XVim2/Info.plist
@@ -24,6 +24,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>A74FBA51-FFEA-4409-B976-6FC3225A6F64</string>
 		<string>92CB09D8-3B74-4EF7-849C-99816039F0E7</string>
 		<string>2FD51EF8-522D-4532-9698-980C4C497FD1</string>
 		<string>B89EAABF-783E-4EBF-80D4-A9EAC69F77F2</string>


### PR DESCRIPTION
I added the UUID for Xcode 11.2 in `Info.plist` file.