### PR TITLE
Fixes command line input bar for Xcode12

### DIFF
--- a/XVim2/Xcode/SourceEditorViewProxy.m
+++ b/XVim2/Xcode/SourceEditorViewProxy.m
@@ -659,19 +659,17 @@ static CGFloat XvimCommandLineAnimationDuration = 0.1;
         height.priority = 250;
         height.active = YES;
 
-        /* TODO:Xcode12
         [NSAnimationContext runAnimationGroup:^(NSAnimationContext* _Nonnull context) {
             context.duration = XvimCommandLineAnimationDuration;
-            NSEdgeInsets insets = scrollView.additionalContentInsets;
+            NSEdgeInsets insets = scrollView.contentInsets;
             self->_cmdLineBottomAnchor.animator.constant = 0;
             insets.bottom += XvimCommandLineHeight;
-            scrollView.animator.additionalContentInsets = insets;
-            [scrollView updateAutomaticContentInsets];
+            scrollView.animator.contentInsets = insets;
+            [scrollView setUpdatingAutoContentInsets:YES];
         }
                     completionHandler:^{
                         self.commandLine.needsDisplay = YES;
                     }];
-        */
     }
 }
 
@@ -680,24 +678,22 @@ static CGFloat XvimCommandLineAnimationDuration = 0.1;
     if (!self.isShowingCommandLine)
         return;
 
-    /* TODO:Xcode12
     let scrollView = [self.sourceEditorView scrollView];
     if ([self.sourceEditorView.class isEqual:NSClassFromString(IDESourceEditorViewClassName)]) {
-        NSEdgeInsets insets = scrollView.additionalContentInsets;
-        insets.bottom = 0;
+        NSEdgeInsets insets = scrollView.contentInsets;
+        insets.bottom -= XvimCommandLineHeight;
 
         [NSAnimationContext runAnimationGroup:^(NSAnimationContext* _Nonnull context) {
             context.duration = XvimCommandLineAnimationDuration;
             self->_cmdLineBottomAnchor.animator.constant = -XvimCommandLineHeight;
-            scrollView.animator.additionalContentInsets = insets;
-            [scrollView updateAutomaticContentInsets];
+            scrollView.animator.contentInsets = insets;
+            [scrollView setUpdatingAutoContentInsets:YES];
         }
                     completionHandler:^{
                         [self.commandLine removeFromSuperview];
                         self->_cmdLineBottomAnchor = nil;
                     }];
     }
-    */
 }
 
 - (NSMutableArray<NSValue*>*)foundRanges

--- a/XVim2/XcodeHeader/SourceEditor/SourceEditorScrollView.h
+++ b/XVim2/XcodeHeader/SourceEditor/SourceEditorScrollView.h
@@ -25,7 +25,6 @@
 }
 
 @property BOOL updatingAutoContentInsets; // @synthesize updatingAutoContentInsets=_updatingAutoContentInsets;
-@property struct NSEdgeInsets additionalContentInsets; // @synthesize additionalContentInsets=_additionalContentInsets;
 @property BOOL isLiveScrolling; // @synthesize isLiveScrolling=_isLiveScrolling;
 @property __weak id <SourceEditorScrollViewScrollerMoved> scrollerMovedDelegate; // @synthesize scrollerMovedDelegate=_scrollerMovedDelegate;
 @property __weak id <SourceEditorPrivateScrollViewDelegate> privateScrollViewDelegate; // @synthesize privateScrollViewDelegate=_privateScrollViewDelegate;
@@ -41,7 +40,6 @@
 - (void)_notifyDelegateOfUserScroll:(id)arg1;
 - (void)_doScroller:(id)arg1 hitPart:(long long)arg2 multiplier:(double)arg3;
 - (void)_updateAutomaticContentInsets;
-- (void)updateAutomaticContentInsets;
 - (void)didEndLiveScrolling;
 - (void)didLiveScrolling;
 - (void)didStartLiveScrolling;


### PR DESCRIPTION
This readds support for showing the command input bar in a way that is compatible with Xcode12.

I have verified that this also works on Xcode11.7.

Closes #310 
