### PR TITLE
fix: Ctrl+E and Ctrl+Y feature and line based scroll feature

### DIFF
--- a/XVim2/Xcode/SourceEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceEditorViewProxy+Scrolling.m
@@ -97,10 +97,12 @@ typedef struct {
 // zero index
 - (LineRange)xvim_visibleLineRange
 {
-    let bottomPoint = NSMakePoint(0.0, self.contentSize.height);
-    
+    let xcode12_workaround_offset = 20.0;
+    let topPoint = NSMakePoint(0.0, self.sourceEditorViewSize.height - self.contentSize.height - xcode12_workaround_offset);
+    let bottomPoint = NSMakePoint(0.0, self.sourceEditorViewSize.height - xcode12_workaround_offset);
+
     NSInteger topLine =
-    [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:NSZeroPoint], 0)]
+    [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:topPoint], 0)]
     .location;
     clamp(topLine, 0, self.lineCount - 1);
     

--- a/XVim2/Xcode/SourceEditorViewProxy.h
+++ b/XVim2/Xcode/SourceEditorViewProxy.h
@@ -243,6 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSRect)bounds;
 - (NSRect)frame;
 - (NSSize)contentSize;
+- (NSSize)sourceEditorViewSize;
 // Utilities
 - (void)scrollRangeToVisible:(NSRange)arg1;
 @property (readonly) NSInteger lineCount;

--- a/XVim2/Xcode/SourceEditorViewProxy.m
+++ b/XVim2/Xcode/SourceEditorViewProxy.m
@@ -621,6 +621,7 @@
 - (NSRect)bounds { return self.sourceEditorView.bounds; }
 - (NSRect)frame { return self.sourceEditorView.frame; }
 - (NSSize)contentSize { return self.sourceEditorView.visibleTextRect.size; }
+- (NSSize)sourceEditorViewSize { return self.sourceEditorView.bounds.size; }
 
 - (XVimCommandLine*)commandLine
 {


### PR DESCRIPTION
hi @pebble8888 

fixed #315 

This PR fixed line based position calculated scroll features.
Only tested on Xcode 12.2

![xvim](https://user-images.githubusercontent.com/425216/101039945-540b8980-35bf-11eb-8e2a-89b3b7a2d1b2.gif)
