### PR TITLE
Fix H, M and L motion

### DIFF
--- a/XVim2/Xcode/SourceEditorViewProxy+Scrolling.m
+++ b/XVim2/Xcode/SourceEditorViewProxy+Scrolling.m
@@ -89,34 +89,6 @@
     [self xvim_syncStateWithScroll:YES];
 }
 
-typedef struct {
-    NSInteger topLine;
-    NSInteger bottomLine;
-} LineRange;
-
-// zero index
-- (LineRange)xvim_visibleLineRange
-{
-    let xcode12_workaround_offset = 20.0;
-    let topPoint = NSMakePoint(0.0, self.sourceEditorViewSize.height - self.contentSize.height - xcode12_workaround_offset);
-    let bottomPoint = NSMakePoint(0.0, self.sourceEditorViewSize.height - xcode12_workaround_offset);
-
-    NSInteger topLine =
-    [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:topPoint], 0)]
-    .location;
-    clamp(topLine, 0, self.lineCount - 1);
-    
-    NSInteger bottomLine =
-    [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:bottomPoint], 0)]
-    .location;
-    clamp(bottomLine, 0, self.lineCount - 1);
-    
-    LineRange r;
-    r.topLine = topLine;
-    r.bottomLine = bottomLine;
-    return r;
-}
-
 - (NSInteger)linesPerPage {
     let linerange = self.xvim_visibleLineRange;
     return linerange.bottomLine - linerange.topLine;

--- a/XVim2/Xcode/SourceEditorViewProxy+XVim.h
+++ b/XVim2/Xcode/SourceEditorViewProxy+XVim.h
@@ -12,6 +12,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef struct {
+    NSInteger topLine;
+    NSInteger bottomLine;
+} LineRange;
+
 @interface SourceEditorViewProxy (XVim)
 - (NSUInteger)xvim_indexOfLineNumber:(NSUInteger)line;
 - (NSUInteger)xvim_indexOfLineNumber:(NSUInteger)line column:(NSUInteger)col;
@@ -36,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)xvim_moveCursor:(NSUInteger)pos preserveColumn:(BOOL)preserve;
 - (XVimRange)xvim_selectedLines;
 - (void)xvim_insertSpaces:(NSUInteger)count replacementRange:(NSRange)replacementRange;
+- (LineRange)xvim_visibleLineRange;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/XVim2/Xcode/SourceEditorViewProxy+XVim.m
+++ b/XVim2/Xcode/SourceEditorViewProxy+XVim.m
@@ -826,6 +826,29 @@
 // UTILITY
 #pragma MARK - UTILITY
 
+// zero index
+- (LineRange)xvim_visibleLineRange
+{
+    let xcode12_workaround_offset = 20.0;
+    let topPoint = NSMakePoint(0.0, self.sourceEditorViewSize.height - self.contentSize.height - xcode12_workaround_offset);
+    let bottomPoint = NSMakePoint(0.0, self.sourceEditorViewSize.height - xcode12_workaround_offset);
+
+    NSInteger topLine =
+    [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:topPoint], 0)]
+    .location;
+    clamp(topLine, 0, self.lineCount - 1);
+
+    NSInteger bottomLine =
+    [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:bottomPoint], 0)]
+    .location;
+    clamp(bottomLine, 0, self.lineCount - 1);
+
+    LineRange r;
+    r.topLine = topLine;
+    r.bottomLine = bottomLine;
+    return r;
+}
+
 - (void)xvim_insertSpaces:(NSUInteger)count replacementRange:(NSRange)replacementRange
 {
     if (count || replacementRange.length) {

--- a/XVim2/Xcode/SourceEditorViewProxy+XVim.m
+++ b/XVim2/Xcode/SourceEditorViewProxy+XVim.m
@@ -867,8 +867,7 @@
 - (NSUInteger)xvim_lineNumberFromBottom:(NSUInteger)count
 {
     NSAssert(0 != count, @"count starts from 1");
-    let bottomPoint = NSMakePoint(0.0, self.contentSize.height);
-    NSInteger bottomLine = [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:bottomPoint], 0)].location;
+    var bottomLine = [self xvim_visibleLineRange].bottomLine;
     clamp(bottomLine, 0, self.lineCount - 1);
     if (count > 1) {
         bottomLine -= (count - 1);
@@ -887,7 +886,7 @@
 - (NSUInteger)xvim_lineNumberFromTop:(NSUInteger)count
 {
     NSAssert(0 != count, @"count starts from 1");
-    NSInteger topLine = [self lineRangeForCharacterRange:NSMakeRange([self characterIndexForInsertionAtPoint:NSZeroPoint], 0)].location;
+    var topLine = [self xvim_visibleLineRange].topLine;
     clamp(topLine, 0, self.lineCount - 1);
     if (count > 1) {
         topLine += (count - 1);


### PR DESCRIPTION
Hi @pebble8888 

`H`, `M` and `L` motion still getting wrong line number in Xcode 12 after fixing for `+Scrolling` impl by #345.

This PR use `xvim_visibleLineRange` method to getting correct visible line range also for `+XVim` impl to fixing `H`, `M`, and `L` motion.