### PR TITLE
Refactor assembly code

### DIFF
--- a/XVim2/Xcode/SourceEditorViewWrapper.s
+++ b/XVim2/Xcode/SourceEditorViewWrapper.s
@@ -51,42 +51,30 @@ _seds_wrapper_call9:
     pushq %rbp
     movq  %rsp, %rbp
 
-# Save registers on stack
+# Allocate memory on stack
 
-    leaq    -240(%rsp), %rsp
-    //andq    0xFFFFFFFFFFFFFFF0, %rsp
-
-    // Callee-saved
-    movq    %rbx, (%rsp)
-    movq    %r12, 8(%rsp)
-    movq    %r13, 16(%rsp)
-    movq    %r14, 24(%rsp)
-    movq    %r15, 32(%rsp)
-
-    // Shuffled args
-    movq    %rdi, 40(%rsp)
-    movq    %rsi, 48(%rsp)
-    movq    %rdx, 56(%rsp)
-    movq    %rcx, 64(%rsp)
-    movq    %r8, 80(%rsp)
-    movq    %r9, 96(%rsp)
-
-    movdqa  %xmm0, 112(%rsp)
-    movdqa  %xmm1, 128(%rsp)
-    movdqa  %xmm2, 144(%rsp)
-    movdqa  %xmm3, 160(%rsp)
-    movdqa  %xmm4, 176(%rsp)
-    movdqa  %xmm5, 192(%rsp)
-    movdqa  %xmm6, 208(%rsp)
-    movdqa  %xmm7, 224(%rsp)
+    leaq    -8(%rsp), %rsp # allocate 8 byte on stack
 
 # Body
-    movq  (%rdi), %r13 # Load the target 'self'
 
-    pushq  $0 # Keep 16-byte SP alignment
-    pushq  8(%rdi)  # Push the target function
+    # We passed UnsafeMutablePointer that allocate 8 byte * 8 memory as 1st argument from Invoker.
+    # %rdi = contextPtr[0] = self (view)
+    # %rdi + 8 = contextPtr[1] = target function pointer
+    # %rdi + 16~56 is reserved for future use case. It can be passed as contextPtr[2~7]
+
+    # Load the target 'self', this is Swift function calling convensions
+    # https://github.com/apple/swift/blob/main/docs/ABI/RegisterUsage.md
+    movq  (%rdi), %r13
+
+    # 8 + 8 = 16 bytes is ok to keeping 16-byte SP alignment, no need allocate more.
+    pushq  8(%rdi)  # Push the target function pointer to stack
 
 # Shuffle up arguments
+
+    # rest of integer arguments (2nd~6th) from Invoker = %rsi, %rdx, %rcx, %r8, %r9
+    # that must be shuffle up to call target function.
+    # Currently we support up to 4 (r9 register is not shuffled up) arguments
+    # for integer that passed as register.
     movq  %rsi, %rdi
     movq  %rdx, %rsi
     movq  %rcx, %rdx
@@ -96,32 +84,17 @@ _seds_wrapper_call9:
 # CALL
     callq *(%rsp)
 
-    addq $16, %rsp
+    addq $8, %rsp
 
-# Restore registers from stack
-    movq    (%rsp), %rbx
-    movq    8(%rsp), %r12
-    movq    16(%rsp), %r13
-    movq    24(%rsp), %r14
-    movq    32(%rsp), %r15
-
-    // Shuffled args
-    movq    40(%rsp), %rdi
-    movq    48(%rsp), %rsi
+# Restore stack pointer position
 
     // RAX, RDX Used for return values
     // RCX Used for return values
     // R8 Used for return values
 
-    movq    96(%rsp), %r9
-
     // XMM0-3 Used for return values
-    movdqa  176(%rsp), %xmm4
-    movdqa  192(%rsp), %xmm5
-    movdqa  208(%rsp), %xmm6
-    movdqa  224(%rsp), %xmm7
 
-    leaq    240(%rsp), %rsp
+    leaq    8(%rsp), %rsp
 
 # Cleanup
     movq %rbp, %rsp

--- a/XVim2/Xcode/SourceEditorViewWrapper.s
+++ b/XVim2/Xcode/SourceEditorViewWrapper.s
@@ -55,6 +55,9 @@ _seds_wrapper_call9:
 
     leaq    -8(%rsp), %rsp # allocate 8 byte on stack
 
+# Save callee-save
+    movq %r13, (%rsp)
+
 # Body
 
     # We passed UnsafeMutablePointer that allocate 8 byte * 8 memory as 1st argument from Invoker.
@@ -86,7 +89,9 @@ _seds_wrapper_call9:
 
     addq $8, %rsp
 
-# Restore stack pointer position
+# Restore registers from stack
+
+    movq (%rsp), %r13
 
     // RAX, RDX Used for return values
     // RCX Used for return values


### PR DESCRIPTION
While researching assembly code porting to arm64, I found `rbx`, `r12-r15` and `xmm0-7` register is not used around invoking swift method.
Additionally, rest of using registers `rsi, rdi, rdx, rcx, r8 and r9` are not callee-save registers.

This PR remove operations using that registers and refactoring before support arm.