### PR TITLE
Add CI by GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: make


### PR DESCRIPTION
github actions provided mac are only supported intel yet.

----

Currently, this CI will check compile able status.

I want to run unit test that implemented inside XVim menu but it is difficult in CI.

- Could not create unit test target for bundle target (XVim2.xcplugin) to invoke by `xcodebuild test`
- Required create self cert then replace codesign of Xcode in CI. It's maybe too long.
- Could not get unit test result for now, only display window.