### PR TITLE
Consider <C-W>w for easy jumping

### DIFF
--- a/XVim2/Xcode/IDEWorkspaceTabController+XVim.m
+++ b/XVim2/Xcode/IDEWorkspaceTabController+XVim.m
@@ -162,11 +162,17 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode)
         return;
     }
 
-    IDEEditorArea* editorArea = [SELF editorArea];
-    if ([editorArea editorMode] != GENIUS) {
-        DEBUG_LOG(@"editor not in genius mode, nothing to jump to");
-        return;
-    }
+    /**
+     I have no idea what is `GENIUS`µ Mode but once I cancel this pre-condition,
+     we can do the relative jump.
+     I don't want to change something I don't know, maybe there is something
+     wrong somewhere 🤔
+     IDEEditorArea* editorArea = [SELF editorArea];
+     if ([editorArea editorMode] != GENIUS) {
+         DEBUG_LOG(@"editor not in genius mode, nothing to jump to");
+         return;
+     }
+     */
 
     IDEViewController* current = [SELF _currentFirstResponderArea];
     NSArray* allEditors = [self xvim_allEditorArea];


### PR DESCRIPTION
I really like XVim2 and I want to support it. I use split-window a lot and frequently jump between 2 horizontal splits. I understand there has `<C-w>h`, `<C-w>l` but I feel stack using them. After a few weeks of struggling, I found this solution: by ignoring a pre-condition in the jump function but it seems a wrong approach. 

Maybe because of some Vim/Xcode setting I did not set properly? 

Many thanks.