### PR TITLE
Fixed visual mode selection when not using spaces for tabs (indenting)

### DIFF
--- a/XVim2/XVim/NSTextStorage+VimOperation.m
+++ b/XVim2/XVim/NSTextStorage+VimOperation.m
@@ -156,13 +156,13 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t* sb, NSUInteger tab
     if (!xvim_sb_at_end(sb)) {
         do {
             if (xvim_sb_peek(sb) == '\t') {
-					if (useTabToIndent) {
-						col += 1;
-					} else {
-						col += tabWidth;
-						if (tabWidth)
-							col -= col % tabWidth;
-					}
+                if (useTabToIndent) {
+                    col += 1;
+                } else {
+                    col += tabWidth;
+                if (tabWidth)
+                    col -= col % tabWidth;
+                }
             }
             else {
                 col++;

--- a/XVim2/XVim/NSTextStorage+VimOperation.m
+++ b/XVim2/XVim/NSTextStorage+VimOperation.m
@@ -24,6 +24,7 @@
 
 - (NSUInteger)xvim_indentWidth { return XVim.instance.options.indentWidth; }
 - (NSUInteger)xvim_tabWidth { return XVim.instance.options.tabWidth; }
+- (BOOL)xvim_useTabsToIndent { return XVim.instance.options.useTabsToIndent; }
 
 #pragma mark Converting between Indexes and Line Numbers
 
@@ -148,16 +149,20 @@
 
 #pragma mark Converting between Indexes and Line Numbers + Columns
 
-static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t* sb, NSUInteger tabWidth)
+static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t* sb, NSUInteger tabWidth, BOOL useTabToIndent)
 {
     NSUInteger col = 0;
 
     if (!xvim_sb_at_end(sb)) {
         do {
             if (xvim_sb_peek(sb) == '\t') {
-                col += tabWidth;
-                if (tabWidth)
-                    col -= col % tabWidth;
+					if (useTabToIndent) {
+						col += 1;
+					} else {
+						col += tabWidth;
+						if (tabWidth)
+							col -= col % tabWidth;
+					}
             }
             else {
                 col++;
@@ -181,7 +186,7 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t* sb, NSUInteger tab
     }
 
     xvim_sb_init(&sb, self.xvim_string, range.location, range);
-    return xvim_sb_count_columns(&sb, self.xvim_tabWidth);
+    return xvim_sb_count_columns(&sb, self.xvim_tabWidth, self.xvim_useTabsToIndent);
 }
 
 - (NSUInteger)xvim_numberOfColumnsInLineAtIndex:(NSUInteger)index
@@ -190,7 +195,7 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t* sb, NSUInteger tab
     xvim_string_buffer_t sb;
 
     xvim_sb_init(&sb, self.xvim_string, range.location, range);
-    return xvim_sb_count_columns(&sb, self.xvim_tabWidth);
+    return xvim_sb_count_columns(&sb, self.xvim_tabWidth, self.xvim_useTabsToIndent);
 }
 
 - (NSUInteger)xvim_indexOfLineNumber:(NSUInteger)num column:(NSUInteger)column

--- a/XVim2/XVim/XVimOptions.h
+++ b/XVim2/XVim/XVimOptions.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSDictionary* highlight;
 @property (nonatomic, readonly) long long indentWidth;
 @property (nonatomic, readonly) long long tabWidth;
+@property (nonatomic, readonly) BOOL useTabsToIndent;
 - (id)getOption:(NSString*)name;
 - (void)setOption:(NSString*)name value:(id)value;
 - (void)setOptionBool:(NSString*)name value:(BOOL)value;

--- a/XVim2/XVim/XVimOptions.m
+++ b/XVim2/XVim/XVimOptions.m
@@ -172,4 +172,12 @@
     }
 }
 
+- (BOOL)useTabsToIndent {
+	@try {
+		return [[NSClassFromString(@"DVTTextPreferences") preferences] useTabsToIndent];
+	}
+	@catch (NSException* e){
+		return NO;
+	}
+}
 @end


### PR DESCRIPTION
The PR fixes visual mode selection issue if project is set to use tabs (not spaces) for indenting.