### PR TITLE
Enabled execution of the external shell commands on the specified text range

### DIFF
--- a/XVim2/XVim/XVimExCommand.m
+++ b/XVim2/XVim/XVimExCommand.m
@@ -553,7 +553,7 @@
         exarg.lineBegin = exarg.lineEnd;
         exarg.lineEnd = tmp;
     }
-
+	// tesst
     // 4. parse command
     // In window command and its argument must be separeted by space
     unichar* tmp = parsing;
@@ -1417,34 +1417,26 @@ xvim_ignore_warning_pop
         }
     }
 	
-#if true
-	[XVimTaskRunner runScript:args.arg withInput:text];
-#else 
-	// TODO:quickfix
     NSUInteger firstFilteredLine = args.lineBegin;
-    NSString* scriptReturn = [XVimTaskRunner runScript:args.arg
-                                             withInput:text
-										   withTimeout:EXTERNAL_COMMAND_TIMEOUT_SECS
-                                          runDirectory:runDir
-											  colWidth:window.commandLine.quickFixColWidth];
-    if (scriptReturn != nil) {
+    NSString* scriptReturn = [XVimTaskRunner runScript:args.arg withInput:text];
+//    NSString* scriptReturn = [XVimTaskRunner runScript:args.arg
+//                                             withInput:text
+//										   withTimeout:EXTERNAL_COMMAND_TIMEOUT_SECS
+//                                          runDirectory:runDir
+//											  colWidth:window.commandLine.quickFixColWidth];
+	 if (scriptReturn != nil) {
         if (args.noRangeSpecified) {
-            // No text range was specified -- open quickfix window to display the result
-            [window showQuickfixWithString:scriptReturn
-                             completionHandler:^{
-                                 [window.currentWorkspaceWindow makeFirstResponder:window.sourceView];
-                             }];
+            // Without text range just display result of a command as status message
+			  [window statusMessage:args.arg];
         }
         else {
             // A text range was specified -- replace the range with the output of the command
             [window.sourceView insertText:scriptReturn];
-
             if (firstFilteredLine != NSNotFound) {
                 [window.sourceView setSelectedRange:NSMakeRange(inputStartLocation, 1)];
             }
         }
     }
-#endif
 }
 
 // Really rubbish way of getting the alt filename

--- a/XVim2/XVim/XVimExCommand.m
+++ b/XVim2/XVim/XVimExCommand.m
@@ -553,7 +553,6 @@
         exarg.lineBegin = exarg.lineEnd;
         exarg.lineEnd = tmp;
     }
-	// tesst
     // 4. parse command
     // In window command and its argument must be separeted by space
     unichar* tmp = parsing;


### PR DESCRIPTION
This PR enables the execution of external shell commands. 

Mainly I needed this to run `swift-format` utility. For example with the following entry in `.xvimrc`
```
nnoremap <space>f :%!swift-format format<cr>
```
it now formats my current open swift file when pressing `space f` - it also works much faster than my previous solution invoking formatter with applescript.

It also works on visual selection. Example from my `.xvimrc`
```
vnoremap <space>b :!/Users/matej/bin/vimtrans<cr>
```
which is also a custom formatter of my swift code.

I thougt it would be useful to have this enabled.