### PR TITLE
Fixes invalid selection position when entering visual mode if line includes TABS

### DIFF
--- a/XVim2/XVim/NSTextStorage+VimOperation.m
+++ b/XVim2/XVim/NSTextStorage+VimOperation.m
@@ -154,14 +154,7 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t* sb, NSUInteger tab
 
     if (!xvim_sb_at_end(sb)) {
         do {
-            if (xvim_sb_peek(sb) == '\t') {
-                col += tabWidth;
-                if (tabWidth)
-                    col -= col % tabWidth;
-            }
-            else {
-                col++;
-            }
+             col++;
         } while (xvim_sb_next(sb));
     }
 


### PR DESCRIPTION
Fixes "jumping" of the cursor when entering visual mode on a line that includes TABS. The issue was reported also here.
https://github.com/XVimProject/XVim2/issues/252

This is simplified fix of another PR which is now closed as this is better solution (Previous PR: https://github.com/XVimProject/XVim2/pull/359)