### PR TITLE
build(make): add x86_64 and arm64 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-xcodebuild:=xcodebuild -configuration
+xcodebuild:=xcodebuild -arch x86_64 -arch arm64 -configuration
 xcode_plugin_path:=$(HOME)/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 simbl_plugin_path:=/Library/Application Support/MacEnhance/Plugins
 


### PR DESCRIPTION
Not sure if this a great idea or not, but in my machine it built with
x86_64 but after adding these arguments it created universal binary.
